### PR TITLE
Explicitly use python2 in shebang

### DIFF
--- a/gnome-keysign.py
+++ b/gnome-keysign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import logging, os, sys, signal
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG, format='%(name)s (%(levelname)s): %(message)s')


### PR DESCRIPTION
Arch Linux for example defaults to python3 when calling python, not python2.