### PR TITLE
Make the fullscreen QR code appear on different displays

### DIFF
--- a/keysign/QRCode.py
+++ b/keysign/QRCode.py
@@ -231,6 +231,26 @@ class FullscreenQRImageWindow(Gtk.Window):
             self.unfullscreen()
             self.hide()
             self.close()
+        elif keyname == 'left' or keyname == 'right':
+            # We're trying to switch monitors
+            screen = self.get_screen()
+            # Determines the monitor the window is currently most visible in
+            n = screen.get_monitor_at_window(screen.get_active_window())
+            n_monitors = screen.get_n_monitors()
+
+            if keyname == 'left':
+                delta = -1
+            elif keyname == 'right':
+                delta = 1
+            else:
+                raise ValueError()
+
+            new_n = (n+delta) % n_monitors
+            log.info("Moving from %d to %d/%d", n, new_n, n_monitors)
+            if n != new_n:
+                # FIXME: Determine whether we need this call to unfullscreen
+                self.unfullscreen()
+                self.fullscreen_on_monitor(self.get_screen(), new_n)
 
 
 def main(data):

--- a/keysign/QRCode.py
+++ b/keysign/QRCode.py
@@ -69,6 +69,9 @@ class QRImage(Gtk.DrawingArea):
         self.log.info('Event %s', dir(event))
         if event.button == 1:
             w = FullscreenQRImageWindow(data=self.data)
+            top_level_window = self.get_toplevel()
+            if top_level_window.is_toplevel():
+                w.set_transient_for(top_level_window)
 
 
     def do_size_allocate(self, event):

--- a/keysign/QRCode.py
+++ b/keysign/QRCode.py
@@ -183,6 +183,25 @@ class QRImage(Gtk.DrawingArea):
 
     data = GObject.property(getter=get_data, setter=set_data)
 
+
+def fullscreen_at_monitor(window, n):
+    """Fullscreens a given window on the n-th monitor
+
+    This is because Gtk's fullscreen_on_monitor seems to
+    be buggy.
+    http://stackoverflow.com/a/39386341/2015768
+    """
+    screen = Gdk.Screen.get_default()
+
+    monitor_n_geo = screen.get_monitor_geometry(n)
+    x = monitor_n_geo.x
+    y = monitor_n_geo.y
+
+    window.move(x,y)
+
+    window.fullscreen()
+
+
 class FullscreenQRImageWindow(Gtk.Window):
     '''Displays a QRImage in a fullscreen window
     
@@ -248,9 +267,13 @@ class FullscreenQRImageWindow(Gtk.Window):
             new_n = (n+delta) % n_monitors
             log.info("Moving from %d to %d/%d", n, new_n, n_monitors)
             if n != new_n:
-                # FIXME: Determine whether we need this call to unfullscreen
-                self.unfullscreen()
-                self.fullscreen_on_monitor(self.get_screen(), new_n)
+                # This call would make it animate a little,
+                # but it looks weird for me, so we don't unfullscreen.
+                # self.unfullscreen()
+                fullscreen_at_monitor(self, new_n)
+                # The following call is broken, unfortunately.
+                # https://bugzilla.gnome.org/show_bug.cgi?id=752677
+                # self.fullscreen_on_monitor(self.get_screen(), new_n)
 
 
 def main(data):


### PR DESCRIPTION
When pressing the left or the right key the window now changes the monitor.
This is helpful when hooked up to a projector.
